### PR TITLE
Add Swagger and API Documentation to Chatbot Service

### DIFF
--- a/backend/chat-service/app/main.py
+++ b/backend/chat-service/app/main.py
@@ -1,6 +1,5 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.openapi.docs import get_swagger_ui_html
 
 tags_metadata = [
     {


### PR DESCRIPTION
This PR integrates Swagger UI and ReDoc documentation into the FastAPI Chatbot Service.
It enables developers to explore and test endpoints directly from the browser and provides clear metadata about the service.

Changes:
- Added Swagger UI (/docs) and ReDoc (/redoc) for API visualization
- Configured API metadata:
   - Title: VendorIQ Chatbot Service
   - Version: 1.0.0
   - Description: AI-driven chatbot for vendor and invoice analysis
- Organized routes using descriptive tags (Health, Chatbot, etc.)

Testing:
1. Run the application:
`uvicorn app.main:app --reload`
2. Open documentation in browser:
   - Swagger UI → http://localhost:8000/docs
   - ReDoc → http://localhost:8000/redoc
3. Check /ping and /chat

Closes #21 
