### PR TITLE
[Authentication service] Add Swagger API Documentation for Authentication Service

### DIFF
--- a/backend/authentication-service/src/main/app.py
+++ b/backend/authentication-service/src/main/app.py
@@ -1,5 +1,6 @@
 from flask import Flask
 from flask_cors import CORS
+from flasgger import Swagger
 from controllers.auth_controller import auth_bp
 import os
 from dotenv import load_dotenv
@@ -11,6 +12,25 @@ CORS(app, supports_credentials=True)
 app.secret_key = os.getenv("SECRET_KEY")
 
 app.register_blueprint(auth_bp)
+
+# Swagger configuration
+swagger_config = {
+    "headers": [],
+    "specs": [
+        {
+            "endpoint": 'apispec',
+            "route": '/apispec.json',
+            "rule_filter": lambda rule: True,  # include all endpoints
+            "model_filter": lambda tag: True,  # include all models
+        }
+    ],
+    "static_url_path": "/flasgger_static",
+    "swagger_ui": True,
+    "specs_route": "/docs/"  # <- Swagger UI available at /docs
+}
+
+# Load external Swagger YAML
+swagger = Swagger(app, config=swagger_config, template_file="../routes/swagger_auth_service.yaml")
 
 @app.route("/")
 def home():

--- a/backend/authentication-service/src/routes/swagger_auth_service.yaml
+++ b/backend/authentication-service/src/routes/swagger_auth_service.yaml
@@ -1,0 +1,78 @@
+swagger: "2.0"
+info:
+  title: Google OAuth2 Authentication Service API
+  version: 1.0.0
+  description: >
+    This service handles Google OAuth2 authentication flow — generating the authorization URL, 
+    exchanging authorization codes for tokens, and managing login/logout sessions.
+servers:
+  - url: http://localhost:5000
+    description: Local development server
+
+paths:
+  /auth/login:
+    get:
+      summary: Generate Google OAuth2 Authorization URL
+      description: Returns the Google OAuth2 consent screen URL where the user will log in.
+      tags:
+        - Authentication
+      responses:
+        "302":
+          description: Redirect to google login
+          
+          
+  /oauth2callback:
+    get:
+      summary: Handle Google OAuth2 Callback
+      description: Exchanges authorization code for tokens, verifies them, and redirects to frontend.
+      tags:
+        - Authentication
+      parameters:
+        - name: code
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Authorization code returned by Google
+      responses:
+        "302":
+          description: Redirect to frontend dashboard on successful authentication
+        "400":
+          description: Invalid credentials or token
+
+  /auth/logout:
+    post:
+      summary: Log out the authenticated user
+      description: Removes the user session and logs out the user.
+      tags:
+        - Authentication
+      responses:
+        "200":
+          description: Logout successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Logged out successfully"
+
+  /:
+    get:
+      summary: Health Check
+      description: Check if the Authentication Service is running.
+      tags:
+        - Utility
+      responses:
+        "200":
+          description: Service running successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Authentication Service is running!"
+


### PR DESCRIPTION
Description

This PR adds Swagger (OpenAPI) documentation for the Authentication Service using Flasgger. The documentation provides a clear and interactive interface to explore all authentication-related endpoints and their request/response models.

Implementations

- Integrated Flasgger with Flask application for Swagger UI support.
- Added external Swagger specification file (swagger_auth_service.yaml) describing Authentication Service APIs.
- Documented endpoints for Google OAuth2 login, callback, logout, and service health check.
- Configured Swagger UI to be accessible via /docs route for better API visibility and testing.

Closes #36 