### PR TITLE
[Frontend] Add user profile section with dropdown and logout in sidebar

### DIFF
--- a/Frontend/src/App.tsx
+++ b/Frontend/src/App.tsx
@@ -25,7 +25,7 @@ const AppRoutes = () => {
         <Route path="/login" element={<Login />} />
         <Route path="/register" element={<Register />} />
         <Route path="/reset" element={<Reset />} />
-        <Route path="*" element={<Navigate to="/" replace />} />
+        <Route path="*" element={<NotFound/>} />
       </Routes>
     );
   }

--- a/Frontend/src/components/AppSidebar.tsx
+++ b/Frontend/src/components/AppSidebar.tsx
@@ -20,11 +20,10 @@ import {
   SidebarHeader,
   SidebarFooter,
 } from "@/components/ui/sidebar";
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import { useSidebar } from "@/components/ui/sidebar";
 import { useAuth } from "@/contexts/AuthContext";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
-import { useNavigate } from "react-router-dom";
 import { useRef, useState } from "react";
 
 const mainMenuItems = [
@@ -145,8 +144,8 @@ export function AppSidebar() {
                 {(user?.username?.[0] || user?.email?.[0] || 'U').toUpperCase()}
               </div>
               <div className="flex-1 min-w-0 text-left">
-                <p className="text-sm font-medium truncate">{user?.username || 'Username'}</p>
-                <p className="text-xs text-muted-foreground truncate">{user?.email || 'user@gmail.com'}</p>
+                <p className="text-sm font-medium truncate">{user?.username}</p>
+                <p className="text-xs text-muted-foreground truncate">{user?.email}</p>
               </div>
               <ChevronsUpDown className="ml-auto size-4" />
             </button>
@@ -163,8 +162,8 @@ export function AppSidebar() {
                 {(user?.username?.[0] || user?.email?.[0] || 'U').toUpperCase()}
               </div>
               <div className="min-w-0">
-                <p className="text-sm font-semibold truncate">{user?.username || 'Username'}</p>
-                <p className="text-xs text-muted-foreground truncate">{user?.email || 'user@gmail.com'}</p>
+                <p className="text-sm font-semibold truncate">{user?.username}</p>
+                <p className="text-xs text-muted-foreground truncate">{user?.email}</p>
               </div>
             </div>
             <div className="space-y-1">


### PR DESCRIPTION
This PR adds a user profile section to the bottom of the sidebar, providing quick access to account details and logout functionality.

Changes Included:

- Added user info section (avatar, name, email) at the bottom of the sidebar.
- Implemented a dropdown menu with profile, contact us and logout option
- Integrated logout functionality to clear authentication and redirect to /login.
- Adjusted dropdown layout to remain responsive with resizable sidebar width.
- Ensured consistent styling across dark and light themes.

Closes #51 