### PR TITLE
[GoogleSheetAnalyticsService]: Implemented Export Google Sheets Data as Downloadable CSV/JSON

### DIFF
--- a/backend/google-sheets-analytics-service/app.js
+++ b/backend/google-sheets-analytics-service/app.js
@@ -3,7 +3,6 @@ import dotenv from "dotenv";
 
 dotenv.config();
 
-//All your source code is inside src/
 import sheetsRoutes from "./src/routes/sheetsRoutes.js";
 import { swaggerDocs } from "./src/routes/swaggerDocs.js";
 

--- a/backend/google-sheets-analytics-service/src/controllers/sheetsController.js
+++ b/backend/google-sheets-analytics-service/src/controllers/sheetsController.js
@@ -39,9 +39,17 @@ export const getTrends = async (req, res) => {
 
 export const exportData = async (req, res) => {
   try {
-    const file = await exportSheetData(req.query.format);
-    res.download(file);
+    const format = req.query.format || "csv";
+    const filePath = await exportSheetData(format);
+
+    return res.download(filePath, (err) => {
+      if (err) {
+        console.error("Error downloading file:", err);
+        return res.status(500).json({ error: "Failed to download file" });
+      }
+    });
   } catch (error) {
-    res.status(500).json({ error: error.message });
+    console.error("Error exporting data:", error);
+    return res.status(500).json({ error: error.message });
   }
 };


### PR DESCRIPTION
This PR adds the export functionality to the Google Sheets Analytics Service. Users can now download sheet data in CSV or JSON format using the new /export endpoint.

Key Changes:

Added export route: GET /api/v1/sheets/export?format=csv|json

Implemented exportSheetData() service:

Fetches full sheet data (A:Z range)

Converts data to CSV or JSON

Saves file in /exports/expenses.csv or /exports/expenses.json

Updated controller with res.download() to enable browser download

Added folder creation logic using fs.mkdirSync()

Updated Swagger documentation for this endpoint

Error handling for unsupported formats and empty sheet cases

Files Modified:

src/routes/sheetsRoutes.js

src/controllers/sheetsController.js

src/services/sheetsService.js

Testing Done:

Verified in Bruno/Postman (correct response format)

Checked /exports folder for saved files

Confirmed download works via browser

Testing:
/api/v1/sheets/export?format=csv|json - run this in you browser to download the file

Issues linked:
Closes #59 